### PR TITLE
Add mock requests to changelog generator tests

### DIFF
--- a/src/lib/__snapshots__/changelog-generator.test.ts.snap
+++ b/src/lib/__snapshots__/changelog-generator.test.ts.snap
@@ -3,92 +3,92 @@
 exports[`Changelog generator > with workspaces > generates the full changelog for a future package release 1`] = `
 "# Changelog
 
-## [gen1 3.0.0](https://github.com/untile/test-github-changelog-generator/releases/tag/gen1-3.0.0) (2023-04-04)
-- Add eevee [\\\\#10](https://github.com/untile/test-github-changelog-generator/pull/10) ([luisdralves](https://github.com/luisdralves))
-- Add pikachu [\\\\#8](https://github.com/untile/test-github-changelog-generator/pull/8) ([luisdralves](https://github.com/luisdralves))
+## [gen1 3.0.0](https://github.com/untile/workspaces/releases/tag/gen1-3.0.0) (2023-04-04)
+- Add eevee [\\\\#10](https://github.com/untile/workspaces/pull/10) ([luisdralves](https://github.com/luisdralves))
+- Add pikachu [\\\\#8](https://github.com/untile/workspaces/pull/8) ([luisdralves](https://github.com/luisdralves))
 
-## [gen1 2.0.0](https://github.com/untile/test-github-changelog-generator/releases/tag/gen1/2.0.0) (2023-03-31)
-- Add starters [\\\\#7](https://github.com/untile/test-github-changelog-generator/pull/7) ([luisdralves](https://github.com/luisdralves))
+## [gen1 2.0.0](https://github.com/untile/workspaces/releases/tag/gen1/2.0.0) (2023-03-31)
+- Add starters [\\\\#7](https://github.com/untile/workspaces/pull/7) ([luisdralves](https://github.com/luisdralves))
 "
 `;
 
 exports[`Changelog generator > with workspaces > generates the full changelog for a future package release 2`] = `
 "# Changelog
 
-## [gen2 3.0.0](https://github.com/untile/test-github-changelog-generator/releases/tag/gen2-3.0.0) (2023-04-04)
-- Add sentret [\\\\#9](https://github.com/untile/test-github-changelog-generator/pull/9) ([luisdralves](https://github.com/luisdralves))
+## [gen2 3.0.0](https://github.com/untile/workspaces/releases/tag/gen2-3.0.0) (2023-04-04)
+- Add sentret [\\\\#9](https://github.com/untile/workspaces/pull/9) ([luisdralves](https://github.com/luisdralves))
 
-## [gen2 2.0.0](https://github.com/untile/test-github-changelog-generator/releases/tag/gen2/2.0.0) (2023-03-31)
-- Add starters [\\\\#7](https://github.com/untile/test-github-changelog-generator/pull/7) ([luisdralves](https://github.com/luisdralves))
+## [gen2 2.0.0](https://github.com/untile/workspaces/releases/tag/gen2/2.0.0) (2023-03-31)
+- Add starters [\\\\#7](https://github.com/untile/workspaces/pull/7) ([luisdralves](https://github.com/luisdralves))
 "
 `;
 
 exports[`Changelog generator > with workspaces > generates the latest changelog for a future package release 1`] = `
 "# Changelog
 
-## [gen1 3.0.0](https://github.com/untile/test-github-changelog-generator/releases/tag/gen1-3.0.0) (2023-04-04)
-- Add eevee [\\\\#10](https://github.com/untile/test-github-changelog-generator/pull/10) ([luisdralves](https://github.com/luisdralves))
-- Add pikachu [\\\\#8](https://github.com/untile/test-github-changelog-generator/pull/8) ([luisdralves](https://github.com/luisdralves))
+## [gen1 3.0.0](https://github.com/untile/workspaces/releases/tag/gen1-3.0.0) (2023-04-04)
+- Add eevee [\\\\#10](https://github.com/untile/workspaces/pull/10) ([luisdralves](https://github.com/luisdralves))
+- Add pikachu [\\\\#8](https://github.com/untile/workspaces/pull/8) ([luisdralves](https://github.com/luisdralves))
 "
 `;
 
 exports[`Changelog generator > with workspaces > generates the latest changelog for a future package release 2`] = `
 "# Changelog
 
-## [gen2 3.0.0](https://github.com/untile/test-github-changelog-generator/releases/tag/gen2-3.0.0) (2023-04-04)
-- Add sentret [\\\\#9](https://github.com/untile/test-github-changelog-generator/pull/9) ([luisdralves](https://github.com/luisdralves))
+## [gen2 3.0.0](https://github.com/untile/workspaces/releases/tag/gen2-3.0.0) (2023-04-04)
+- Add sentret [\\\\#9](https://github.com/untile/workspaces/pull/9) ([luisdralves](https://github.com/luisdralves))
 "
 `;
 
 exports[`Changelog generator > with workspaces > regenerates the full changelog for a package 1`] = `
 "# Changelog
 
-## [gen1 2.0.0](https://github.com/untile/test-github-changelog-generator/releases/tag/gen1/2.0.0) (2023-03-31)
-- Add starters [\\\\#7](https://github.com/untile/test-github-changelog-generator/pull/7) ([luisdralves](https://github.com/luisdralves))
+## [gen1 2.0.0](https://github.com/untile/workspaces/releases/tag/gen1/2.0.0) (2023-03-31)
+- Add starters [\\\\#7](https://github.com/untile/workspaces/pull/7) ([luisdralves](https://github.com/luisdralves))
 "
 `;
 
 exports[`Changelog generator > with workspaces > regenerates the full changelog for a package 2`] = `
 "# Changelog
 
-## [gen2 2.0.0](https://github.com/untile/test-github-changelog-generator/releases/tag/gen2/2.0.0) (2023-03-31)
-- Add starters [\\\\#7](https://github.com/untile/test-github-changelog-generator/pull/7) ([luisdralves](https://github.com/luisdralves))
+## [gen2 2.0.0](https://github.com/untile/workspaces/releases/tag/gen2/2.0.0) (2023-03-31)
+- Add starters [\\\\#7](https://github.com/untile/workspaces/pull/7) ([luisdralves](https://github.com/luisdralves))
 "
 `;
 
 exports[`Changelog generator > without workspaces > generates the full changelog for a future root release 1`] = `
 "# Changelog
 
-## [5.0.0](https://github.com/untile/test-github-changelog-generator-no-workspaces/releases/tag/5.0.0) (2023-04-04)
-- Add snorlax [\\\\#5](https://github.com/untile/test-github-changelog-generator-no-workspaces/pull/5) ([luisdralves](https://github.com/luisdralves))
+## [5.0.0](https://github.com/untile/no-workspaces/releases/tag/5.0.0) (2023-04-04)
+- Add snorlax [\\\\#5](https://github.com/untile/no-workspaces/pull/5) ([luisdralves](https://github.com/luisdralves))
 
-## [4.0.0](https://github.com/untile/test-github-changelog-generator-no-workspaces/releases/tag/4.0.0) (2023-04-03)
-- Add eevee [\\\\#4](https://github.com/untile/test-github-changelog-generator-no-workspaces/pull/4) ([luisdralves](https://github.com/luisdralves))
-- Add sentret [\\\\#3](https://github.com/untile/test-github-changelog-generator-no-workspaces/pull/3) ([luisdralves](https://github.com/luisdralves))
-- Add pikachu [\\\\#2](https://github.com/untile/test-github-changelog-generator-no-workspaces/pull/2) ([luisdralves](https://github.com/luisdralves))
+## [4.0.0](https://github.com/untile/no-workspaces/releases/tag/4.0.0) (2023-04-03)
+- Add eevee [\\\\#4](https://github.com/untile/no-workspaces/pull/4) ([luisdralves](https://github.com/luisdralves))
+- Add sentret [\\\\#3](https://github.com/untile/no-workspaces/pull/3) ([luisdralves](https://github.com/luisdralves))
+- Add pikachu [\\\\#2](https://github.com/untile/no-workspaces/pull/2) ([luisdralves](https://github.com/luisdralves))
 
-## [3.0.0](https://github.com/untile/test-github-changelog-generator-no-workspaces/releases/tag/3.0.0) (2023-03-31)
-- Add starters [\\\\#1](https://github.com/untile/test-github-changelog-generator-no-workspaces/pull/1) ([luisdralves](https://github.com/luisdralves))
+## [3.0.0](https://github.com/untile/no-workspaces/releases/tag/3.0.0) (2023-03-31)
+- Add starters [\\\\#1](https://github.com/untile/no-workspaces/pull/1) ([luisdralves](https://github.com/luisdralves))
 "
 `;
 
 exports[`Changelog generator > without workspaces > generates the latest changelog for a future root release 1`] = `
 "# Changelog
 
-## [5.0.0](https://github.com/untile/test-github-changelog-generator-no-workspaces/releases/tag/5.0.0) (2023-04-04)
-- Add snorlax [\\\\#5](https://github.com/untile/test-github-changelog-generator-no-workspaces/pull/5) ([luisdralves](https://github.com/luisdralves))
+## [5.0.0](https://github.com/untile/no-workspaces/releases/tag/5.0.0) (2023-04-04)
+- Add snorlax [\\\\#5](https://github.com/untile/no-workspaces/pull/5) ([luisdralves](https://github.com/luisdralves))
 "
 `;
 
 exports[`Changelog generator > without workspaces > regenerates the full changelog 1`] = `
 "# Changelog
 
-## [4.0.0](https://github.com/untile/test-github-changelog-generator-no-workspaces/releases/tag/4.0.0) (2023-04-03)
-- Add eevee [\\\\#4](https://github.com/untile/test-github-changelog-generator-no-workspaces/pull/4) ([luisdralves](https://github.com/luisdralves))
-- Add sentret [\\\\#3](https://github.com/untile/test-github-changelog-generator-no-workspaces/pull/3) ([luisdralves](https://github.com/luisdralves))
-- Add pikachu [\\\\#2](https://github.com/untile/test-github-changelog-generator-no-workspaces/pull/2) ([luisdralves](https://github.com/luisdralves))
+## [4.0.0](https://github.com/untile/no-workspaces/releases/tag/4.0.0) (2023-04-03)
+- Add eevee [\\\\#4](https://github.com/untile/no-workspaces/pull/4) ([luisdralves](https://github.com/luisdralves))
+- Add sentret [\\\\#3](https://github.com/untile/no-workspaces/pull/3) ([luisdralves](https://github.com/luisdralves))
+- Add pikachu [\\\\#2](https://github.com/untile/no-workspaces/pull/2) ([luisdralves](https://github.com/luisdralves))
 
-## [3.0.0](https://github.com/untile/test-github-changelog-generator-no-workspaces/releases/tag/3.0.0) (2023-03-31)
-- Add starters [\\\\#1](https://github.com/untile/test-github-changelog-generator-no-workspaces/pull/1) ([luisdralves](https://github.com/luisdralves))
+## [3.0.0](https://github.com/untile/no-workspaces/releases/tag/3.0.0) (2023-03-31)
+- Add starters [\\\\#1](https://github.com/untile/no-workspaces/pull/1) ([luisdralves](https://github.com/luisdralves))
 "
 `;

--- a/src/lib/changelog-generator.test.ts
+++ b/src/lib/changelog-generator.test.ts
@@ -5,6 +5,7 @@
 import { ChangelogOptions } from 'src/types';
 import { changelogGenerator } from './changelog-generator';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fetchMock from 'fetch-mock';
 
 /**
  * Common options for tests with workspaces.
@@ -13,7 +14,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const commonWorkspacesOptions: Partial<ChangelogOptions> = {
   baseBranch: 'main',
   owner: 'untile',
-  repo: 'test-github-changelog-generator'
+  repo: 'workspaces'
 };
 
 /**
@@ -22,7 +23,35 @@ const commonWorkspacesOptions: Partial<ChangelogOptions> = {
 
 const commonNoWorkspacesOptions: Partial<ChangelogOptions> = {
   ...commonWorkspacesOptions,
-  repo: 'test-github-changelog-generator-no-workspaces'
+  repo: 'no-workspaces'
+};
+
+/**
+ * `fetchMockHelper` util.
+ */
+
+const fetchMockHelper = (query: string, input: object, output: object) => {
+  fetchMock.mock({
+    matcher: (url, opts) => {
+      const body = JSON.parse(opts.body as string);
+
+      return (
+        url === 'https://api.github.com/graphql' &&
+        body.query.includes(query) &&
+        Object.entries(input).every(
+          ([key, value]) =>
+            JSON.stringify(body.variables[key]) === JSON.stringify(value)
+        )
+      );
+    },
+    method: 'POST',
+    response: {
+      body: {
+        data: output
+      },
+      status: 200
+    }
+  });
 };
 
 /**
@@ -40,6 +69,147 @@ describe('Changelog generator', () => {
   });
 
   describe('without workspaces', () => {
+    beforeEach(() => {
+      fetchMockHelper(
+        'repositoryCreatedAt',
+        {
+          owner: 'untile',
+          repo: 'no-workspaces'
+        },
+        {
+          repository: {
+            createdAt: '2023-03-31T11:33:40Z'
+          }
+        }
+      );
+
+      fetchMockHelper(
+        'getReleases',
+        {
+          owner: 'untile',
+          repo: 'no-workspaces'
+        },
+        {
+          repository: {
+            releases: {
+              nodes: [
+                {
+                  createdAt: '2023-04-03T13:15:17Z',
+                  name: '4.0.0',
+                  tagName: '4.0.0',
+                  url: 'https://github.com/untile/no-workspaces/releases/tag/4.0.0'
+                },
+                {
+                  createdAt: '2023-03-31T11:56:57Z',
+                  name: '3.0.0',
+                  tagName: '3.0.0',
+                  url: 'https://github.com/untile/no-workspaces/releases/tag/3.0.0'
+                }
+              ]
+            }
+          }
+        }
+      );
+
+      fetchMockHelper(
+        'pullRequestsBefore',
+        {
+          base: 'main',
+          first: 100,
+          owner: 'untile',
+          repo: 'no-workspaces'
+        },
+        {
+          repository: {
+            pullRequests: {
+              nodes: [
+                {
+                  author: {
+                    login: 'luisdralves',
+                    url: 'https://github.com/luisdralves'
+                  },
+                  mergedAt: '2023-04-03T13:19:33Z',
+                  number: 5,
+                  title: 'Add snorlax',
+                  url: 'https://github.com/untile/no-workspaces/pull/5'
+                },
+                {
+                  author: {
+                    login: 'luisdralves',
+                    url: 'https://github.com/luisdralves'
+                  },
+                  mergedAt: '2023-03-31T12:01:59Z',
+                  number: 4,
+                  title: 'Add eevee',
+                  url: 'https://github.com/untile/no-workspaces/pull/4'
+                },
+                {
+                  author: {
+                    login: 'luisdralves',
+                    url: 'https://github.com/luisdralves'
+                  },
+                  mergedAt: '2023-03-31T12:00:50Z',
+                  number: 3,
+                  title: 'Add sentret',
+                  url: 'https://github.com/untile/no-workspaces/pull/3'
+                },
+                {
+                  author: {
+                    login: 'luisdralves',
+                    url: 'https://github.com/luisdralves'
+                  },
+                  mergedAt: '2023-03-31T11:59:35Z',
+                  number: 2,
+                  title: 'Add pikachu',
+                  url: 'https://github.com/untile/no-workspaces/pull/2'
+                },
+                {
+                  author: {
+                    login: 'luisdralves',
+                    url: 'https://github.com/luisdralves'
+                  },
+                  mergedAt: '2023-03-31T11:54:26Z',
+                  number: 1,
+                  title: 'Add starters',
+                  url: 'https://github.com/untile/no-workspaces/pull/1'
+                }
+              ],
+              pageInfo: {
+                endCursor:
+                  'Y3Vyc29yOnYyOpK5MjAyMy0wMy0zMVQxMjo1NDoyOCswMTowMM5NWFhu',
+                hasNextPage: false
+              }
+            }
+          }
+        }
+      );
+
+      fetchMockHelper(
+        'latestRelease',
+        {
+          owner: 'untile',
+          repo: 'no-workspaces'
+        },
+        {
+          repository: {
+            latestRelease: {
+              nodes: [
+                {
+                  createdAt: '2023-04-03T13:15:17Z',
+                  name: '4.0.0',
+                  tagCommit: {
+                    committedDate: '2023-04-03T13:15:17Z'
+                  },
+                  tagName: '4.0.0',
+                  url: 'https://github.com/untile/no-workspaces/releases/tag/4.0.0'
+                }
+              ]
+            }
+          }
+        }
+      );
+    });
+
     it('regenerates the full changelog', async () => {
       expect(
         await changelogGenerator({
@@ -95,6 +265,172 @@ describe('Changelog generator', () => {
   });
 
   describe('with workspaces', () => {
+    beforeEach(() => {
+      fetchMockHelper(
+        'repositoryCreatedAt',
+        {
+          owner: 'untile',
+          repo: 'workspaces'
+        },
+        {
+          repository: {
+            createdAt: '2023-03-30T20:59:23Z'
+          }
+        }
+      );
+
+      fetchMockHelper(
+        'getReleases',
+        {
+          owner: 'untile',
+          repo: 'workspaces'
+        },
+        {
+          repository: {
+            releases: {
+              nodes: [
+                {
+                  createdAt: '2023-03-31T09:58:16Z',
+                  name: 'gen2 2.0.0',
+                  tagName: 'gen2/2.0.0',
+                  url: 'https://github.com/untile/workspaces/releases/tag/gen2/2.0.0'
+                },
+                {
+                  createdAt: '2023-03-31T09:47:29Z',
+                  name: 'gen1 2.0.0',
+                  tagName: 'gen1/2.0.0',
+                  url: 'https://github.com/untile/workspaces/releases/tag/gen1/2.0.0'
+                }
+              ]
+            }
+          }
+        }
+      );
+
+      fetchMockHelper(
+        'pullRequestsBefore',
+        {
+          base: 'main',
+          first: 100,
+          labels: ['gen1'],
+          owner: 'untile',
+          repo: 'workspaces'
+        },
+        {
+          repository: {
+            pullRequests: {
+              nodes: [
+                {
+                  author: {
+                    login: 'luisdralves',
+                    url: 'https://github.com/luisdralves'
+                  },
+                  mergedAt: '2023-03-31T10:04:28Z',
+                  number: 10,
+                  title: 'Add eevee',
+                  url: 'https://github.com/untile/workspaces/pull/10'
+                },
+                {
+                  author: {
+                    login: 'luisdralves',
+                    url: 'https://github.com/luisdralves'
+                  },
+                  mergedAt: '2023-03-31T10:01:26Z',
+                  number: 8,
+                  title: 'Add pikachu',
+                  url: 'https://github.com/untile/workspaces/pull/8'
+                },
+                {
+                  author: {
+                    login: 'luisdralves',
+                    url: 'https://github.com/luisdralves'
+                  },
+                  mergedAt: '2023-03-31T09:37:35Z',
+                  number: 7,
+                  title: 'Add starters',
+                  url: 'https://github.com/untile/workspaces/pull/7'
+                }
+              ],
+              pageInfo: {
+                endCursor:
+                  'Y3Vyc29yOnYyOpK5MjAyMy0wMy0zMVQxMDozNzozNyswMTowMM5NVcU8',
+                hasNextPage: false
+              }
+            }
+          }
+        }
+      );
+
+      fetchMockHelper(
+        'pullRequestsBefore',
+        {
+          base: 'main',
+          first: 100,
+          labels: ['gen2'],
+          owner: 'untile',
+          repo: 'workspaces'
+        },
+        {
+          repository: {
+            pullRequests: {
+              nodes: [
+                {
+                  author: {
+                    login: 'luisdralves',
+                    url: 'https://github.com/luisdralves'
+                  },
+                  mergedAt: '2023-03-31T10:03:06Z',
+                  number: 9,
+                  title: 'Add sentret',
+                  url: 'https://github.com/untile/workspaces/pull/9'
+                },
+                {
+                  author: {
+                    login: 'luisdralves',
+                    url: 'https://github.com/luisdralves'
+                  },
+                  mergedAt: '2023-03-31T09:37:35Z',
+                  number: 7,
+                  title: 'Add starters',
+                  url: 'https://github.com/untile/workspaces/pull/7'
+                }
+              ],
+              pageInfo: {
+                endCursor:
+                  'Y3Vyc29yOnYyOpK5MjAyMy0wMy0zMVQxMDozNzozNyswMTowMM5NVcU8',
+                hasNextPage: false
+              }
+            }
+          }
+        }
+      );
+
+      fetchMockHelper(
+        'latestRelease',
+        {
+          owner: 'untile',
+          repo: 'workspaces'
+        },
+        {
+          repository: {
+            latestRelease: {
+              nodes: [
+                {
+                  createdAt: '2023-03-31T09:58:16Z',
+                  name: 'gen2 2.0.0',
+                  tagCommit: {
+                    committedDate: '2023-03-31T09:58:16Z'
+                  },
+                  tagName: 'gen2/2.0.0',
+                  url: 'https://github.com/untile/workspaces/releases/tag/gen2/2.0.0'
+                }
+              ]
+            }
+          }
+        }
+      );
+    });
+
     it('regenerates the full changelog for a package', async () => {
       expect(
         await changelogGenerator({


### PR DESCRIPTION
This PR mocks the requests in `src/lib/changelog-generator.test.ts` so that this repo does not depend on external repos any more. This was achieved by intercepting the real requests to then hardcode their responses.

After this PR is merged, https://github.com/untile/test-github-changelog-generator and https://github.com/untile/test-github-changelog-generator-no-workspaces can be deleted