### PR TITLE
Fix publish action npm authentication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '14.18.0'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install module dependencies
         run: yarn


### PR DESCRIPTION
This PR fixes the npm authentication in the publish workflow by explicitly setting the `registery-url` option. GitHub's machines use a custom config from `/home/runner/work/_temp/.npmrc` which presumably has a different registry url