### PR TITLE
Fix NPM publish action wrong registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '14.18.0'
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: 'https://registry.npmjs.com'
 
       - name: Install module dependencies
         run: yarn


### PR DESCRIPTION
This PR adds the `.npmrc` to the repo to override the possible Github machine's default configuration.