### PR TITLE
Rebuild changelog by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # github-changelog-generator
 
 Generate changelog files from the project's GitHub PRs
-Based on [uphold/github-changelog-generator](https://github.com/uphold/github-changelog-generator) and [fossamagna/github-changelog-generator](https://github.com/fossamagna/github-changelog-generator)
 
 ## Usage
 
@@ -27,9 +26,9 @@ $ yarn github-changelog-generator --help
                               generate the changelog                      [string]
     -l, --labels              Comma-separated labels to filter pull requests by
                                                                            [array]
+        --latest              Build only the latest changelog            [boolean]
     -o, --owner               Owner of the repository                     [string]
     -r, --repo                Name of the repository                      [string]
-        --rebuild             Rebuild the full changelog                 [boolean]
     -d, --output              Path of the changelog file. If omitted, it will be
                               automatically inferred.                     [string]
         --stdout              Outputs to stdout instead of a file.       [boolean]
@@ -38,11 +37,10 @@ $ yarn github-changelog-generator --help
   Generate changelog files from the project's GitHub PRs
 ```
 
-### `--rebuild`
 To generate a changelog for your GitHub project, use the following command:
 
 ```sh
-$ yarn github-changelog-generator --rebuild
+$ yarn github-changelog-generator
 ```
 
 This will generate the changelog with all the releases and output it to `CHANGELOG.md`.
@@ -55,10 +53,17 @@ $ yarn github-changelog-generator --base-branch development
 ```
 
 ### `--future-release`
-This allows you to specify a new release and generate its changelog. This changelog includes all pull requests (PRs) that have been merged since the last release. To also include changelogs for past releases, use the `--rebuild` option with `--future-release`. At least one of these two options is required; otherwise, the output will be empty.
+This allows you to specify a new release and generate its changelog. This changelog includes all pull requests (PRs) that have been merged since the last release.
 
 ```sh
 $ yarn github-changelog-generator --future-release 1.0.0
+```
+
+### `--latest`
+You can generate only the changelog for the latest release, ommiting past releases. This is not recommended as it can lead to bugs.
+
+```sh
+$ yarn github-changelog-generator --future-release 1.0.0 --latest
 ```
 
 ### `--package-name`
@@ -71,7 +76,7 @@ $ yarn github-changelog-generator --future-release 1.0.0 --package-name project-
 In monorepos, it is necessary to add labels to PRs because it is the way to identify the changes and generate separate changelogs for each package. For example, using the labeler https://github.com/actions/labeler
 
 ### `--output`, `--stdout`
-You can specify a path to a changelog file using the `--output` option. If the file already exists, the new changelog will be appended to the top. If used with `--rebuild`, the file will be overwritten.
+You can specify a path to a changelog file using the `--output` option. If the file already exists, it will be overwritten. If used with `--latest`, the new changelog will be appended to the top.
 
 ```sh
 $ yarn github-changelog-generator --future-release 1.0.0 --output CHANGELOG.md
@@ -83,7 +88,7 @@ If both the `--stdout` and `--output` options are omited, it will automatically 
 If you are not inside your project's folder structure, you will need to manually specify the owner and name of the repository:
 
 ```sh
-$ yarn github-changelog-generator --rebuild --owner untile --repo github-changelog-generator
+$ yarn github-changelog-generator --owner untile --repo github-changelog-generator
 ```
 
 ### `--labels`

--- a/src/constants/commands.ts
+++ b/src/constants/commands.ts
@@ -49,8 +49,8 @@ export function defineCommands(yargs: Argv): Argv {
       describe: 'Name of the repository',
       type: 'string'
     })
-    .option('rebuild', {
-      describe: 'Rebuild the full changelog',
+    .option('latest', {
+      describe: 'Build only the latest changelog',
       type: 'boolean'
     })
     .option('output', {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,10 +19,10 @@ interface CamelCaseOptions {
   futureRelease?: string;
   futureReleaseTag?: string;
   labels?: string[];
+  latest?: boolean;
   output?: string;
   owner?: string;
   packageName?: string;
-  rebuild?: boolean;
   repo?: string;
   stdout?: boolean;
 }
@@ -47,7 +47,7 @@ function writeChangelog(changelog: string, args: Args) {
     );
   }
 
-  if (args.rebuild) {
+  if (!args.latest) {
     writeFileSync(output, changelog, { encoding: 'utf-8' });
 
     return;

--- a/src/lib/changelog-generator.test.ts
+++ b/src/lib/changelog-generator.test.ts
@@ -213,8 +213,7 @@ describe('Changelog generator', () => {
     it('regenerates the full changelog', async () => {
       expect(
         await changelogGenerator({
-          ...commonNoWorkspacesOptions,
-          rebuild: true
+          ...commonNoWorkspacesOptions
         })
       ).toMatchSnapshot();
     });
@@ -223,7 +222,8 @@ describe('Changelog generator', () => {
       expect(
         await changelogGenerator({
           ...commonNoWorkspacesOptions,
-          futureRelease: '5.0.0'
+          futureRelease: '5.0.0',
+          latest: true
         })
       ).toMatchSnapshot();
     });
@@ -232,8 +232,7 @@ describe('Changelog generator', () => {
       expect(
         await changelogGenerator({
           ...commonNoWorkspacesOptions,
-          futureRelease: '5.0.0',
-          rebuild: true
+          futureRelease: '5.0.0'
         })
       ).toMatchSnapshot();
     });
@@ -242,7 +241,8 @@ describe('Changelog generator', () => {
       try {
         await changelogGenerator({
           ...commonNoWorkspacesOptions,
-          futureRelease: '4.0.0'
+          futureRelease: '4.0.0',
+          latest: true
         });
       } catch (error) {
         expect(error).toMatchObject({
@@ -253,8 +253,7 @@ describe('Changelog generator', () => {
       try {
         await changelogGenerator({
           ...commonNoWorkspacesOptions,
-          futureRelease: '4.0.0',
-          rebuild: true
+          futureRelease: '4.0.0'
         });
       } catch (error) {
         expect(error).toMatchObject({
@@ -435,21 +434,39 @@ describe('Changelog generator', () => {
       expect(
         await changelogGenerator({
           ...commonWorkspacesOptions,
-          packageName: 'gen1',
-          rebuild: true
+          packageName: 'gen1'
         })
       ).toMatchSnapshot();
 
       expect(
         await changelogGenerator({
           ...commonWorkspacesOptions,
-          packageName: 'gen2',
-          rebuild: true
+          packageName: 'gen2'
         })
       ).toMatchSnapshot();
     });
 
     it('generates the latest changelog for a future package release', async () => {
+      expect(
+        await changelogGenerator({
+          ...commonWorkspacesOptions,
+          futureRelease: '3.0.0',
+          latest: true,
+          packageName: 'gen1'
+        })
+      ).toMatchSnapshot();
+
+      expect(
+        await changelogGenerator({
+          ...commonWorkspacesOptions,
+          futureRelease: '3.0.0',
+          latest: true,
+          packageName: 'gen2'
+        })
+      ).toMatchSnapshot();
+    });
+
+    it('generates the full changelog for a future package release', async () => {
       expect(
         await changelogGenerator({
           ...commonWorkspacesOptions,
@@ -467,31 +484,12 @@ describe('Changelog generator', () => {
       ).toMatchSnapshot();
     });
 
-    it('generates the full changelog for a future package release', async () => {
-      expect(
-        await changelogGenerator({
-          ...commonWorkspacesOptions,
-          futureRelease: '3.0.0',
-          packageName: 'gen1',
-          rebuild: true
-        })
-      ).toMatchSnapshot();
-
-      expect(
-        await changelogGenerator({
-          ...commonWorkspacesOptions,
-          futureRelease: '3.0.0',
-          packageName: 'gen2',
-          rebuild: true
-        })
-      ).toMatchSnapshot();
-    });
-
     it('fails when requesting a future release that already exists', async () => {
       try {
         await changelogGenerator({
           ...commonWorkspacesOptions,
           futureRelease: '2.0.0',
+          latest: true,
           packageName: 'gen1'
         });
       } catch (error) {
@@ -504,8 +502,7 @@ describe('Changelog generator', () => {
         await changelogGenerator({
           ...commonWorkspacesOptions,
           futureRelease: '2.0.0',
-          packageName: 'gen1',
-          rebuild: true
+          packageName: 'gen1'
         });
       } catch (error) {
         expect(error).toMatchObject({

--- a/src/lib/changelog-generator.ts
+++ b/src/lib/changelog-generator.ts
@@ -12,7 +12,7 @@ import { getGitRepo } from 'src/core/utils';
  */
 
 export async function changelogGenerator(options: Partial<ChangelogOptions>) {
-  const { baseBranch, futureRelease, futureReleaseTag, labels, rebuild } =
+  const { baseBranch, futureRelease, futureReleaseTag, labels, latest } =
     options;
 
   const token = process.env.GITHUB_TOKEN;
@@ -37,9 +37,9 @@ export async function changelogGenerator(options: Partial<ChangelogOptions>) {
     token
   } as ChangelogOptions);
 
-  const releases = await (rebuild
-    ? fetcher.fetchFullChangelog()
-    : fetcher.fetchLatestChangelog());
+  const releases = await (latest
+    ? fetcher.fetchLatestChangelog()
+    : fetcher.fetchFullChangelog());
 
   return formatChangelog(releases);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,9 +7,9 @@ export interface ChangelogOptions {
   futureRelease?: string;
   futureReleaseTag?: string;
   labels?: string[];
+  latest?: boolean;
   owner: string;
   packageName?: string;
-  rebuild?: boolean;
   repo: string;
   token?: string;
 }


### PR DESCRIPTION
This PR removes the `rebuild` option and adds the `latest` option. It is the opposite.