### PR TITLE
Fix Homepage URL in Package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,14 @@
     "github-changelog-generator": "bin/cli.js"
   },
   "main": "dist/cjs/index.js",
+  "homepage": "https://github.com/untile/github-changelog-generator/tree/master#readme",
+  "bugs": {
+    "url": "https://github.com/untile/github-changelog-generator/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/untile/github-changelog-generator.git"
+  },
   "module": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",
   "files": [


### PR DESCRIPTION
This PR adds the missing Homepage URL so that it can be displayed on the NPM page, giving users access to the source code. It also adds the bugs and repository missing Package.json keys.