### PR TITLE
Fix changelog not picking up release without name

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $ yarn github-changelog-generator --future-release 1.0.0
 ```
 
 ### `--latest`
-You can generate only the changelog for the latest release, ommiting past releases. This is not recommended as it can lead to bugs.
+You can generate only the changelog for the latest release, omitting past releases. This is not recommended as it can lead to bugs.
 
 ```sh
 $ yarn github-changelog-generator --future-release 1.0.0 --latest
@@ -93,7 +93,9 @@ If you are working with workspaces, you can keep a separate changelog for each p
 $ yarn github-changelog-generator --future-release 1.0.0 --package-name project-x
 ```
 
-In monorepos, it is necessary to add labels to PRs because it is the way to identify the changes and generate separate changelogs for each package. For example, using the labeler https://github.com/actions/labeler
+> #### ⚠️ In monorepos, it is necessary to add labels to PRs because it is the way to identify the changes and generate separate changelogs for each package. For example, using the labeler https://github.com/actions/labeler.
+
+> #### 🔥 In order to parse tags correctly, the tag convention must be `<package-name>/<version>`
 
 ### `--output`, `--stdout`
 You can specify a path to a changelog file using the `--output` option. If the file already exists, it will be overwritten. If used with `--latest`, the new changelog will be appended to the top.
@@ -102,7 +104,7 @@ You can specify a path to a changelog file using the `--output` option. If the f
 $ yarn github-changelog-generator --future-release 1.0.0 --output CHANGELOG.md
 ```
 
-If both the `--stdout` and `--output` options are omited, it will automatically write to a `CHANGELOG.md` file in the project root. If used with `--package-name`, it will instead output to that package's root. The same appending/overwitting logic as `--output` applies.
+If both the `--stdout` and `--output` options are omitted, it will automatically write to a `CHANGELOG.md` file in the project root. If used with `--package-name`, it will instead output to that package's root. The same appending/overwriting logic as `--output` applies.
 
 ### `--owner`, `--repo`
 If you are not inside your project's folder structure, you will need to manually specify the owner and name of the repository:

--- a/src/core/fetcher.test.ts
+++ b/src/core/fetcher.test.ts
@@ -353,7 +353,7 @@ describe('ChangelogFetcher', () => {
     const latestChangelog = await changelogFetcher.fetchLatestChangelog();
 
     expect(latestChangelog).toHaveLength(1);
-    expect(latestChangelog[0].tagName).toEqual('some-package-4.0.0');
+    expect(latestChangelog[0].tagName).toEqual('some-package/4.0.0');
     expect(latestChangelog[0].name).toEqual('some-package 4.0.0');
     expect(latestChangelog[0].pullRequests).toEqual(mockPullRequests);
 

--- a/src/core/fetcher.ts
+++ b/src/core/fetcher.ts
@@ -72,7 +72,7 @@ export class ChangelogFetcher {
     this.futureReleaseTag =
       this.futureReleaseTag ??
       (this.packageName
-        ? `${this.packageName.toLowerCase()}-${this.futureRelease}`
+        ? `${this.packageName.toLowerCase()}/${this.futureRelease}`
         : this.futureRelease);
 
     this.labels = this.packageName
@@ -123,14 +123,27 @@ export class ChangelogFetcher {
       throw new Error('Changelog already on the latest release');
     }
 
-    return [
+    const allReleases = [
       ...futureRelease ? [futureRelease] : [],
       ...result?.repository?.releases?.nodes ?? []
-    ].filter(
-      ({ name }) =>
-        !this.packageName ||
-        name.toLowerCase().startsWith(this.packageName.toLowerCase())
-    );
+    ];
+
+    if (!this.packageName) {
+      // If theres no package name, we can just return all releases.
+      return allReleases;
+    }
+
+    // We filter out releases that don't match with the package name
+    // convention `<packageName>/vx.x.x`.
+    return allReleases.filter(({ tagName }) => {
+      if (!tagName) {
+        throw new Error('No tag name found');
+      }
+
+      return tagName
+        .toLowerCase()
+        .startsWith(`${this?.packageName?.toLowerCase()}/`);
+    });
   }
 
   /**

--- a/src/core/formatter.test.ts
+++ b/src/core/formatter.test.ts
@@ -107,4 +107,214 @@ describe('formatChangelog', () => {
 
     expect(formatChangelog(releases)).toEqual(expectedOutput);
   });
+
+  it('should handle multiple releases with pull requests', () => {
+    const releases: Release[] = [
+      {
+        createdAt: '2023-03-01T00:00:00.000Z',
+        name: 'Release v1.0.0',
+        pullRequests: [
+          {
+            author: {
+              login: 'user1',
+              url: 'https://example.com/user1'
+            },
+            mergedAt: '2023-01-01T00:00:00.000Z',
+            number: 1,
+            title: 'Remove feature',
+            url: 'https://example.com/pull/1'
+          },
+          {
+            author: {
+              login: 'user1',
+              url: 'https://example.com/user1'
+            },
+            mergedAt: '2023-02-01T00:00:00.000Z',
+            number: 2,
+            title: 'Improve feature',
+            url: 'https://example.com/pull/2'
+          }
+        ],
+        tagName: 'v1.0.0',
+        url: 'https://example.com/release/v1.0.0'
+      },
+      {
+        createdAt: '2023-05-01T00:00:00.000Z',
+        name: 'Release v1.0.1',
+        pullRequests: [
+          {
+            author: {
+              login: 'user1',
+              url: 'https://example.com/user1'
+            },
+            mergedAt: '2023-04-01T00:00:00.000Z',
+            number: 3,
+            title: 'Add new feature',
+            url: 'https://example.com/pull/3'
+          }
+        ],
+        tagName: 'v1.0.1',
+        url: 'https://example.com/release/v1.0.1'
+      },
+      {
+        createdAt: '2023-07-01T00:00:00.000Z',
+        name: 'Release v1.0.2',
+        pullRequests: [
+          {
+            author: {
+              login: 'user1',
+              url: 'https://example.com/user1'
+            },
+            mergedAt: '2023-05-01T00:00:00.000Z',
+            number: 4,
+            title: 'Add other feature',
+            url: 'https://example.com/pull/4'
+          }
+        ],
+        tagName: 'v1.0.2',
+        url: 'https://example.com/release/v1.0.2'
+      },
+      {
+        createdAt: '2023-09-01T00:00:00.000Z',
+        name: 'Release v1.1.0',
+        pullRequests: [
+          {
+            author: {
+              login: 'user1',
+              url: 'https://example.com/user1'
+            },
+            mergedAt: '2023-08-01T00:00:00.000Z',
+            number: 5,
+            title: 'Add another feature',
+            url: 'https://example.com/pull/5'
+          }
+        ],
+        tagName: 'v1.1.0',
+        url: 'https://example.com/release/v1.1.0'
+      }
+    ];
+
+    const expectedOutput = `# Changelog
+
+## [Release v1.0.0](https://example.com/release/v1.0.0) (2023-03-01)
+- Remove feature [\\#1](https://example.com/pull/1) ([user1](https://example.com/user1))
+- Improve feature [\\#2](https://example.com/pull/2) ([user1](https://example.com/user1))
+
+## [Release v1.0.1](https://example.com/release/v1.0.1) (2023-05-01)
+- Add new feature [\\#3](https://example.com/pull/3) ([user1](https://example.com/user1))
+
+## [Release v1.0.2](https://example.com/release/v1.0.2) (2023-07-01)
+- Add other feature [\\#4](https://example.com/pull/4) ([user1](https://example.com/user1))
+
+## [Release v1.1.0](https://example.com/release/v1.1.0) (2023-09-01)
+- Add another feature [\\#5](https://example.com/pull/5) ([user1](https://example.com/user1))
+`;
+
+    expect(formatChangelog(releases)).toEqual(expectedOutput);
+  });
+
+  it('should handle multiple releases with pull requests without release name', () => {
+    const releases: Release[] = [
+      {
+        createdAt: '2023-03-01T00:00:00.000Z',
+        name: '',
+        pullRequests: [
+          {
+            author: {
+              login: 'user1',
+              url: 'https://example.com/user1'
+            },
+            mergedAt: '2023-01-01T00:00:00.000Z',
+            number: 1,
+            title: 'Remove feature',
+            url: 'https://example.com/pull/1'
+          },
+          {
+            author: {
+              login: 'user1',
+              url: 'https://example.com/user1'
+            },
+            mergedAt: '2023-02-01T00:00:00.000Z',
+            number: 2,
+            title: 'Improve feature',
+            url: 'https://example.com/pull/2'
+          }
+        ],
+        tagName: 'v1.0.0',
+        url: 'https://example.com/release/v1.0.0'
+      },
+      {
+        createdAt: '2023-05-01T00:00:00.000Z',
+        name: '',
+        pullRequests: [
+          {
+            author: {
+              login: 'user1',
+              url: 'https://example.com/user1'
+            },
+            mergedAt: '2023-04-01T00:00:00.000Z',
+            number: 3,
+            title: 'Add new feature',
+            url: 'https://example.com/pull/3'
+          }
+        ],
+        tagName: 'v1.0.1',
+        url: 'https://example.com/release/v1.0.1'
+      },
+      {
+        createdAt: '2023-07-01T00:00:00.000Z',
+        name: '',
+        pullRequests: [
+          {
+            author: {
+              login: 'user1',
+              url: 'https://example.com/user1'
+            },
+            mergedAt: '2023-05-01T00:00:00.000Z',
+            number: 4,
+            title: 'Add other feature',
+            url: 'https://example.com/pull/4'
+          }
+        ],
+        tagName: 'v1.0.2',
+        url: 'https://example.com/release/v1.0.2'
+      },
+      {
+        createdAt: '2023-09-01T00:00:00.000Z',
+        name: '',
+        pullRequests: [
+          {
+            author: {
+              login: 'user1',
+              url: 'https://example.com/user1'
+            },
+            mergedAt: '2023-08-01T00:00:00.000Z',
+            number: 5,
+            title: 'Add another feature',
+            url: 'https://example.com/pull/5'
+          }
+        ],
+        tagName: 'v1.1.0',
+        url: 'https://example.com/release/v1.1.0'
+      }
+    ];
+
+    const expectedOutput = `# Changelog
+
+## [v1.0.0](https://example.com/release/v1.0.0) (2023-03-01)
+- Remove feature [\\#1](https://example.com/pull/1) ([user1](https://example.com/user1))
+- Improve feature [\\#2](https://example.com/pull/2) ([user1](https://example.com/user1))
+
+## [v1.0.1](https://example.com/release/v1.0.1) (2023-05-01)
+- Add new feature [\\#3](https://example.com/pull/3) ([user1](https://example.com/user1))
+
+## [v1.0.2](https://example.com/release/v1.0.2) (2023-07-01)
+- Add other feature [\\#4](https://example.com/pull/4) ([user1](https://example.com/user1))
+
+## [v1.1.0](https://example.com/release/v1.1.0) (2023-09-01)
+- Add another feature [\\#5](https://example.com/pull/5) ([user1](https://example.com/user1))
+`;
+
+    expect(formatChangelog(releases)).toEqual(expectedOutput);
+  });
 });

--- a/src/lib/__snapshots__/changelog-generator.test.ts.snap
+++ b/src/lib/__snapshots__/changelog-generator.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Changelog generator > with workspaces > generates the full changelog for a future package release 1`] = `
 "# Changelog
 
-## [gen1 3.0.0](https://github.com/untile/workspaces/releases/tag/gen1-3.0.0) (2023-04-04)
+## [gen1 3.0.0](https://github.com/untile/workspaces/releases/tag/gen1/3.0.0) (2023-04-04)
 - Add eevee [\\\\#10](https://github.com/untile/workspaces/pull/10) ([luisdralves](https://github.com/luisdralves))
 - Add pikachu [\\\\#8](https://github.com/untile/workspaces/pull/8) ([luisdralves](https://github.com/luisdralves))
 
@@ -15,7 +15,7 @@ exports[`Changelog generator > with workspaces > generates the full changelog fo
 exports[`Changelog generator > with workspaces > generates the full changelog for a future package release 2`] = `
 "# Changelog
 
-## [gen2 3.0.0](https://github.com/untile/workspaces/releases/tag/gen2-3.0.0) (2023-04-04)
+## [gen2 3.0.0](https://github.com/untile/workspaces/releases/tag/gen2/3.0.0) (2023-04-04)
 - Add sentret [\\\\#9](https://github.com/untile/workspaces/pull/9) ([luisdralves](https://github.com/luisdralves))
 
 ## [gen2 2.0.0](https://github.com/untile/workspaces/releases/tag/gen2/2.0.0) (2023-03-31)
@@ -26,7 +26,7 @@ exports[`Changelog generator > with workspaces > generates the full changelog fo
 exports[`Changelog generator > with workspaces > generates the latest changelog for a future package release 1`] = `
 "# Changelog
 
-## [gen1 3.0.0](https://github.com/untile/workspaces/releases/tag/gen1-3.0.0) (2023-04-04)
+## [gen1 3.0.0](https://github.com/untile/workspaces/releases/tag/gen1/3.0.0) (2023-04-04)
 - Add eevee [\\\\#10](https://github.com/untile/workspaces/pull/10) ([luisdralves](https://github.com/luisdralves))
 - Add pikachu [\\\\#8](https://github.com/untile/workspaces/pull/8) ([luisdralves](https://github.com/luisdralves))
 "
@@ -35,7 +35,7 @@ exports[`Changelog generator > with workspaces > generates the latest changelog 
 exports[`Changelog generator > with workspaces > generates the latest changelog for a future package release 2`] = `
 "# Changelog
 
-## [gen2 3.0.0](https://github.com/untile/workspaces/releases/tag/gen2-3.0.0) (2023-04-04)
+## [gen2 3.0.0](https://github.com/untile/workspaces/releases/tag/gen2/3.0.0) (2023-04-04)
 - Add sentret [\\\\#9](https://github.com/untile/workspaces/pull/9) ([luisdralves](https://github.com/luisdralves))
 "
 `;


### PR DESCRIPTION
This PR fixes releases that do not have a name associated. This instead uses the tag name to be identifiable.
The tests were updated and improved to cover this requirement.