### PR TITLE
Fix error when unable to infer path to changelog

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 /**
  * Module dependencies.
  */
@@ -71,13 +73,23 @@ async function run() {
   const changelog = await changelogGenerator(args);
 
   if (args.stdout) {
-    // eslint-disable-next-line no-console
     console.log(changelog);
 
     return;
   }
 
-  writeChangelog(changelog, args);
+  try {
+    writeChangelog(changelog, args);
+  } catch {
+    console.warn(`
+      ⚠️ Warning
+      Unable to infer path to CHANGELOG.md.
+      "${path.resolve('.')}" does not seem to be inside an instance of "${args.owner}/${args.repo}"
+      Will output to stdout instead.
+    `);
+
+    console.log(changelog);
+  }
 }
 
 run();


### PR DESCRIPTION
When manually specifying the repo from outside, it would fail because it would be unable to find the root of the project or the package.

Instead of just a node error, it now shows a meaningful message and the changelog:
```

      ⚠️ Warning
      Unable to infer path to CHANGELOG.md.
      "/Users/luisalves/Documents/github-changelog-generator-untile" does not seem to be inside an instance of "untile/js-configs"
      Will output to stdout instead.


# Changelog

(rest of the changelog)
```