### PR TITLE
Fix latest release behaviour and restore default

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ $ yarn github-changelog-generator --help
                               generate the changelog                      [string]
     -l, --labels              Comma-separated labels to filter pull requests by
                                                                            [array]
-        --latest              Build only the latest changelog            [boolean]
     -o, --owner               Owner of the repository                     [string]
     -r, --repo                Name of the repository                      [string]
+        --rebuild             Rebuild the full changelog                 [boolean]
     -d, --output              Path of the changelog file. If omitted, it will be
                               automatically inferred.                     [string]
         --stdout              Outputs to stdout instead of a file.       [boolean]
@@ -57,10 +57,11 @@ $ yarn github-changelog-generator --help
   Generate changelog files from the project's GitHub PRs
 ```
 
+### `--rebuild`
 To generate a changelog for your GitHub project, use the following command:
 
 ```sh
-$ yarn github-changelog-generator
+$ yarn github-changelog-generator --rebuild
 ```
 
 This will generate the changelog with all the releases and output it to `CHANGELOG.md`.
@@ -73,17 +74,10 @@ $ yarn github-changelog-generator --base-branch development
 ```
 
 ### `--future-release`
-This allows you to specify a new release and generate its changelog. This changelog includes all pull requests (PRs) that have been merged since the last release.
+This allows you to specify a new release and generate its changelog. This changelog includes all pull requests (PRs) that have been merged since the last release. To also include changelogs for past releases, use the `--rebuild` option with `--future-release`. At least one of these two options is required; otherwise, the output will be empty.
 
 ```sh
 $ yarn github-changelog-generator --future-release 1.0.0
-```
-
-### `--latest`
-You can generate only the changelog for the latest release, omitting past releases. This is not recommended as it can lead to bugs.
-
-```sh
-$ yarn github-changelog-generator --future-release 1.0.0 --latest
 ```
 
 ### `--package-name`
@@ -98,7 +92,7 @@ $ yarn github-changelog-generator --future-release 1.0.0 --package-name project-
 > #### 🔥 In order to parse tags correctly, the tag convention must be `<package-name>/<version>`
 
 ### `--output`, `--stdout`
-You can specify a path to a changelog file using the `--output` option. If the file already exists, it will be overwritten. If used with `--latest`, the new changelog will be appended to the top.
+You can specify a path to a changelog file using the `--output` option. If the file already exists, the new changelog will be appended to the top. If used with `--rebuild`, the file will be overwritten.
 
 ```sh
 $ yarn github-changelog-generator --future-release 1.0.0 --output CHANGELOG.md
@@ -110,7 +104,7 @@ If both the `--stdout` and `--output` options are omitted, it will automatically
 If you are not inside your project's folder structure, you will need to manually specify the owner and name of the repository:
 
 ```sh
-$ yarn github-changelog-generator --owner untile --repo github-changelog-generator
+$ yarn github-changelog-generator --rebuild --owner untile --repo github-changelog-generator
 ```
 
 ### `--labels`

--- a/src/constants/commands.ts
+++ b/src/constants/commands.ts
@@ -49,8 +49,8 @@ export function defineCommands(yargs: Argv): Argv {
       describe: 'Name of the repository',
       type: 'string'
     })
-    .option('latest', {
-      describe: 'Build only the latest changelog',
+    .option('rebuild', {
+      describe: 'Rebuild the full changelog',
       type: 'boolean'
     })
     .option('output', {

--- a/src/constants/queries.ts
+++ b/src/constants/queries.ts
@@ -22,17 +22,20 @@ export const getReleasesQuery = `
  */
 
 export const latestReleaseQuery = `
-  query latestRelease($owner: String!, $repo: String!) {
+  query latestRelease($owner: String!, $repo: String!, $after:String) {
     repository(owner: $owner, name: $repo) {
-      latestRelease: releases(first: 1, orderBy: { field: CREATED_AT, direction: DESC }) {
-        nodes {
-          createdAt
-          name
-          tagName
-          tagCommit: tagCommit {
-            committedDate
+      latestRelease: releases(first: 1, orderBy: {field: CREATED_AT, direction: DESC}, after: $after) {
+        edges {
+          cursor
+          node {
+            createdAt
+            name
+            tagName
+            tagCommit {
+              committedDate
+            }
+            url
           }
-          url
         }
       }
     }

--- a/src/core/fetcher.test.ts
+++ b/src/core/fetcher.test.ts
@@ -154,7 +154,7 @@ describe('ChangelogFetcher', () => {
           data: {
             repository: {
               latestRelease: {
-                nodes: [mockLatestRelease]
+                edges: [{ node: mockLatestRelease }]
               }
             }
           }

--- a/src/core/fetcher.ts
+++ b/src/core/fetcher.ts
@@ -151,15 +151,26 @@ export class ChangelogFetcher {
    */
 
   async getLatestRelease(): Promise<Release | undefined> {
-    const result: LatestReleaseQueryResponse = await this.client(
-      latestReleaseQuery,
-      {
-        owner: this.owner,
-        repo: this.repo
-      }
-    );
+    let result: LatestReleaseQueryResponse;
+    let after: string | null = null;
+    let latestRelease: Release;
 
-    const latestRelease = result.repository.latestRelease.nodes[0];
+    do {
+      result = await this.client(
+        latestReleaseQuery,
+        {
+          after,
+          owner: this.owner,
+          repo: this.repo
+        }
+      );
+
+      after = result.repository.latestRelease.edges[0].cursor;
+      latestRelease = result.repository.latestRelease.edges[0].node;
+    } while (this.packageName && latestRelease.tagName
+      .toLowerCase()
+      .startsWith(`${this.packageName.toLowerCase()}/`)
+    );
 
     return latestRelease;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,10 +21,10 @@ interface CamelCaseOptions {
   futureRelease?: string;
   futureReleaseTag?: string;
   labels?: string[];
-  latest?: boolean;
   output?: string;
   owner?: string;
   packageName?: string;
+  rebuild?: boolean;
   repo?: string;
   stdout?: boolean;
 }
@@ -49,7 +49,7 @@ function writeChangelog(changelog: string, args: Args) {
     );
   }
 
-  if (!args.latest) {
+  if (args.rebuild) {
     writeFileSync(output, changelog, { encoding: 'utf-8' });
 
     return;

--- a/src/lib/changelog-generator.test.ts
+++ b/src/lib/changelog-generator.test.ts
@@ -193,8 +193,8 @@ describe('Changelog generator', () => {
         {
           repository: {
             latestRelease: {
-              nodes: [
-                {
+              edges: [{
+                node: {
                   createdAt: '2023-04-03T13:15:17Z',
                   name: '4.0.0',
                   tagCommit: {
@@ -203,7 +203,7 @@ describe('Changelog generator', () => {
                   tagName: '4.0.0',
                   url: 'https://github.com/untile/no-workspaces/releases/tag/4.0.0'
                 }
-              ]
+              }]
             }
           }
         }
@@ -213,7 +213,8 @@ describe('Changelog generator', () => {
     it('regenerates the full changelog', async () => {
       expect(
         await changelogGenerator({
-          ...commonNoWorkspacesOptions
+          ...commonNoWorkspacesOptions,
+          rebuild: true
         })
       ).toMatchSnapshot();
     });
@@ -222,8 +223,7 @@ describe('Changelog generator', () => {
       expect(
         await changelogGenerator({
           ...commonNoWorkspacesOptions,
-          futureRelease: '5.0.0',
-          latest: true
+          futureRelease: '5.0.0'
         })
       ).toMatchSnapshot();
     });
@@ -232,7 +232,8 @@ describe('Changelog generator', () => {
       expect(
         await changelogGenerator({
           ...commonNoWorkspacesOptions,
-          futureRelease: '5.0.0'
+          futureRelease: '5.0.0',
+          rebuild: true
         })
       ).toMatchSnapshot();
     });
@@ -241,8 +242,7 @@ describe('Changelog generator', () => {
       try {
         await changelogGenerator({
           ...commonNoWorkspacesOptions,
-          futureRelease: '4.0.0',
-          latest: true
+          futureRelease: '4.0.0'
         });
       } catch (error) {
         expect(error).toMatchObject({
@@ -253,7 +253,8 @@ describe('Changelog generator', () => {
       try {
         await changelogGenerator({
           ...commonNoWorkspacesOptions,
-          futureRelease: '4.0.0'
+          futureRelease: '4.0.0',
+          rebuild: true
         });
       } catch (error) {
         expect(error).toMatchObject({
@@ -407,14 +408,16 @@ describe('Changelog generator', () => {
       fetchMockHelper(
         'latestRelease',
         {
+          after: null,
           owner: 'untile',
           repo: 'workspaces'
         },
         {
           repository: {
             latestRelease: {
-              nodes: [
-                {
+              edges: [{
+                cursor: 'cursor',
+                node: {
                   createdAt: '2023-03-31T09:58:16Z',
                   name: 'gen2 2.0.0',
                   tagCommit: {
@@ -423,7 +426,33 @@ describe('Changelog generator', () => {
                   tagName: 'gen2/2.0.0',
                   url: 'https://github.com/untile/workspaces/releases/tag/gen2/2.0.0'
                 }
-              ]
+              }]
+            }
+          }
+        }
+      );
+
+      fetchMockHelper(
+        'latestRelease',
+        {
+          after: 'cursor',
+          owner: 'untile',
+          repo: 'workspaces'
+        },
+        {
+          repository: {
+            latestRelease: {
+              edges: [{
+                node: {
+                  createdAt: '2023-03-31T09:58:16Z',
+                  name: 'gen1 2.0.0',
+                  tagCommit: {
+                    committedDate: '2023-03-31T09:58:16Z'
+                  },
+                  tagName: 'gen1/2.0.0',
+                  url: 'https://github.com/untile/workspaces/releases/tag/gen1/2.0.0'
+                }
+              }]
             }
           }
         }
@@ -434,14 +463,16 @@ describe('Changelog generator', () => {
       expect(
         await changelogGenerator({
           ...commonWorkspacesOptions,
-          packageName: 'gen1'
+          packageName: 'gen1',
+          rebuild: true
         })
       ).toMatchSnapshot();
 
       expect(
         await changelogGenerator({
           ...commonWorkspacesOptions,
-          packageName: 'gen2'
+          packageName: 'gen2',
+          rebuild: true
         })
       ).toMatchSnapshot();
     });
@@ -451,7 +482,6 @@ describe('Changelog generator', () => {
         await changelogGenerator({
           ...commonWorkspacesOptions,
           futureRelease: '3.0.0',
-          latest: true,
           packageName: 'gen1'
         })
       ).toMatchSnapshot();
@@ -460,7 +490,6 @@ describe('Changelog generator', () => {
         await changelogGenerator({
           ...commonWorkspacesOptions,
           futureRelease: '3.0.0',
-          latest: true,
           packageName: 'gen2'
         })
       ).toMatchSnapshot();
@@ -471,7 +500,8 @@ describe('Changelog generator', () => {
         await changelogGenerator({
           ...commonWorkspacesOptions,
           futureRelease: '3.0.0',
-          packageName: 'gen1'
+          packageName: 'gen1',
+          rebuild: true
         })
       ).toMatchSnapshot();
 
@@ -479,7 +509,8 @@ describe('Changelog generator', () => {
         await changelogGenerator({
           ...commonWorkspacesOptions,
           futureRelease: '3.0.0',
-          packageName: 'gen2'
+          packageName: 'gen2',
+          rebuild: true
         })
       ).toMatchSnapshot();
     });
@@ -489,7 +520,6 @@ describe('Changelog generator', () => {
         await changelogGenerator({
           ...commonWorkspacesOptions,
           futureRelease: '2.0.0',
-          latest: true,
           packageName: 'gen1'
         });
       } catch (error) {
@@ -502,7 +532,8 @@ describe('Changelog generator', () => {
         await changelogGenerator({
           ...commonWorkspacesOptions,
           futureRelease: '2.0.0',
-          packageName: 'gen1'
+          packageName: 'gen1',
+          rebuild: true
         });
       } catch (error) {
         expect(error).toMatchObject({

--- a/src/lib/changelog-generator.ts
+++ b/src/lib/changelog-generator.ts
@@ -12,7 +12,7 @@ import { getGitRepo } from 'src/core/utils';
  */
 
 export async function changelogGenerator(options: Partial<ChangelogOptions>) {
-  const { baseBranch, futureRelease, futureReleaseTag, labels, latest } =
+  const { baseBranch, futureRelease, futureReleaseTag, labels, rebuild } =
     options;
 
   const token = process.env.GITHUB_TOKEN;
@@ -37,9 +37,9 @@ export async function changelogGenerator(options: Partial<ChangelogOptions>) {
     token
   } as ChangelogOptions);
 
-  const releases = await (latest
-    ? fetcher.fetchLatestChangelog()
-    : fetcher.fetchFullChangelog());
+  const releases = await (rebuild
+    ? fetcher.fetchFullChangelog()
+    : fetcher.fetchLatestChangelog());
 
   return formatChangelog(releases);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,9 +7,9 @@ export interface ChangelogOptions {
   futureRelease?: string;
   futureReleaseTag?: string;
   labels?: string[];
-  latest?: boolean;
   owner: string;
   packageName?: string;
+  rebuild?: boolean;
   repo: string;
   token?: string;
 }
@@ -73,7 +73,10 @@ export type ReleasesQueryResponse = {
 export type LatestReleaseQueryResponse = {
   repository: {
     latestRelease: {
-      nodes: [Release];
+      edges: [{
+        cursor: string;
+        node: Release;
+      }];
     };
   };
 };


### PR DESCRIPTION
In #8, we identified that there was an issue with requesting the latest release when working with monorepos. The latest release does not necessarily match the package we are working with. The solution we found was to rebuild by default, and have `--latest` as an optional flag.

In this PR, #8 is reverted and an alternate solution is implemented. We find the latest release of the specific package. It is now robust and can be restored to the default behaviour, with `--rebuild` going back to optional.

If it is too late to change defaults, we can at least fix this for when the `--latest` option is on
